### PR TITLE
Update critical usage status message for clarity

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -165,7 +165,8 @@ async function showUsageDetails() {
             message += `Estimated High Usage: ${timeDetails['Estimated High Usage']}\n`;
         }
 
-        const statusText = status.isCriticalUsage ? 'Status: 🔴 CRITICAL - Very high usage!' :
+        const statusText = status.usagePercentage >= 100 ? 'Status: 🔴 CRITICAL - Exceeded rate limit!' :
+            status.isCriticalUsage ? 'Status: 🔴 CRITICAL - Very high usage!' :
             status.isHighUsage ? 'Status: 🟡 WARNING - High usage' :
                 'Status: 🟢 NORMAL - Typical usage level';
 


### PR DESCRIPTION
# Why

<img width="357" alt="Screenshot 2025-07-04 at 13 51 12" src="https://github.com/user-attachments/assets/bbbee997-3029-4cde-aa19-3471b3442b7f" />
